### PR TITLE
#26 resolve variable on runner side with freemarker

### DIFF
--- a/runner/build.gradle
+++ b/runner/build.gradle
@@ -37,6 +37,7 @@ repositories {
 dependencies {
     def withoutX = { exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core:2.9.5' }
 
+	compile 'org.freemarker:freemarker:2.3.28'
     compile group: 'org.apache.spark', name: 'spark-core_2.11', version: '2.4.3'
     compile group: 'org.apache.spark', name: 'spark-streaming_2.11', version: '2.4.3'
     compile 'org.apache.beam:beam-runners-spark:2.9.0'

--- a/runner/src/main/java/org/ananas/runner/api/HttpHandler.java
+++ b/runner/src/main/java/org/ananas/runner/api/HttpHandler.java
@@ -45,7 +45,7 @@ class HttpHandler {
 						PaginationBody.class);
 
 		Paginator paginator =
-				SourcePaginator.of(id, paginationBody.type, paginationBody.config, paginationBody.variables);
+				SourcePaginator.of(id, paginationBody.type, paginationBody.config, paginationBody.params);
 		Dataframe dataframe = paginator.paginate(page == null ? 0 : Integer.valueOf(page),
 				pageSize == null ? 1000 : Integer.valueOf(pageSize));
 		return JsonUtil.toJson(ApiResponseBuilder.Of().OK(dataframe).build());

--- a/runner/src/main/java/org/ananas/runner/api/Services.java
+++ b/runner/src/main/java/org/ananas/runner/api/Services.java
@@ -1,5 +1,6 @@
 package org.ananas.runner.api;
 
+import freemarker.template.TemplateException;
 import org.ananas.runner.model.core.DagRequest;
 import org.ananas.runner.model.core.Dataframe;
 import org.ananas.runner.model.steps.commons.build.Builder;
@@ -12,8 +13,9 @@ import java.util.Map;
 
 public class Services {
 
-	protected static Object runDag(String id, String token, String body) throws java.io.IOException {
+	protected static Object runDag(String id, String token, String body) throws java.io.IOException, TemplateException {
 		DagRequest req = JsonUtil.fromJson(body, DagRequest.class);
+		req = req.resolveVariables();
 
 		Builder builder = new DagBuilder(req.dag, false, req.goals, req.params, req.engine);
 
@@ -30,8 +32,9 @@ public class Services {
 		return JsonUtil.toJson(ApiResponseBuilder.Of().OK(results).build());
 	}
 
-	protected static Object testDag(String body) throws java.io.IOException {
+	protected static Object testDag(String body) throws java.io.IOException, TemplateException {
 		DagRequest req = JsonUtil.fromJson(body, DagRequest.class);
+		req = req.resolveVariables();
 		return testDag(req);
 	}
 

--- a/runner/src/main/java/org/ananas/runner/model/core/DagRequest.java
+++ b/runner/src/main/java/org/ananas/runner/model/core/DagRequest.java
@@ -1,16 +1,30 @@
 package org.ananas.runner.model.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
 import lombok.Data;
+import org.ananas.runner.api.JsonUtil;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DagRequest {
+	public static Configuration TEMPLATE_CFG = new Configuration(Configuration.VERSION_2_3_27);
+	static {
+		TEMPLATE_CFG.setDefaultEncoding("UTF-8");
+		TEMPLATE_CFG.setLogTemplateExceptions(false);
+		TEMPLATE_CFG.setWrapUncheckedExceptions(true);
+	}
 
 	@Data
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -67,14 +81,61 @@ public class DagRequest {
 		}
 	}
 
-	public Map<String, Object> params;
+	static public class Variable {
+		public String name;
+		public String type;
+		public String description;
+		public String scope;
+		public String value;
+
+		public Date convertToDate() {
+			// ISO8601
+			DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+			OffsetDateTime offsetDateTime = OffsetDateTime.parse(this.value, timeFormatter);
+			Date date = Date.from(Instant.from(offsetDateTime));
+			return date;
+		}
+
+		public Double convertToNumber() {
+			return Double.parseDouble(this.value);
+		}
+	}
+
+	public Map<String, Variable> params;
 	public Set<String> goals;
 	public Engine engine;
-
 	public Dag dag;
 
 	public DagRequest() {
 		this.params = new HashMap<>();
 		this.goals = new HashSet<>();
+	}
+
+	public DagRequest resolveVariables() throws IOException, TemplateException {
+		String rawReq = JsonUtil.toJson(this);
+
+		Template t = new Template("DagRequest", new StringReader(rawReq), TEMPLATE_CFG);
+
+		// build model
+		Map model = new HashMap();
+		for (String key : this.params.keySet()) {
+			Variable v = this.params.get(key);
+			switch(v.type) {
+				case "number":
+					model.put(key, v.convertToNumber());
+					break;
+				case "date":
+					model.put(key, v.convertToDate());
+					break;
+				default:
+					model.put(key, v.value);
+			}
+		}
+
+		Writer out = new StringWriter();
+		t.process(model, out);
+
+		String transformedTemplate = out.toString();
+		return JsonUtil.fromJson(transformedTemplate, DagRequest.class);
 	}
 }

--- a/runner/src/main/java/org/ananas/runner/model/core/PaginationBody.java
+++ b/runner/src/main/java/org/ananas/runner/model/core/PaginationBody.java
@@ -9,6 +9,6 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PaginationBody {
 	public String type;
-	public Map<String, Object> variables;
+	public Map<String, DagRequest.Variable> params;
 	public Map<String, Object> config;
 }

--- a/runner/src/main/java/org/ananas/runner/model/core/Project.java
+++ b/runner/src/main/java/org/ananas/runner/model/core/Project.java
@@ -45,7 +45,7 @@ public class Project {
 	}
 
 
-	public DagRequest toDagRequest(String stepId, Map<String, Object> params) {
+	public DagRequest toDagRequest(String stepId, Map<String, DagRequest.Variable> params) {
 		DagRequest req = new DagRequest();
 		req.dag = new Dag();
 		req.dag.connections = this.dag.connections;

--- a/runner/src/main/java/org/ananas/runner/model/steps/commons/build/DagBuilder.java
+++ b/runner/src/main/java/org/ananas/runner/model/steps/commons/build/DagBuilder.java
@@ -36,9 +36,9 @@ public class DagBuilder implements Builder {
 
 
 	boolean isTest;
-	Map<String, Object> variables;
+	Map<String, DagRequest.Variable> variables;
 
-	public DagBuilder(Dag d, boolean isTest, Set<String> goals, Map<String, Object> variables, DagRequest.Engine engine) {
+	public DagBuilder(Dag d, boolean isTest, Set<String> goals, Map<String, DagRequest.Variable> variables, DagRequest.Engine engine) {
 		this.dag = new AnanasGraph(d, goals).reverse().subDag(goals).reverse();
 		System.out.println(this.dag);
 		this.stepIds = goals;
@@ -87,7 +87,7 @@ public class DagBuilder implements Builder {
 		Stack<PipelineContext> contexts = new Stack<>();
 		Set<Step> topologicallySortedSteps = this.dag.topologicalSort();
 		for (Step step : topologicallySortedSteps) {
-			VariableRender.render(this.variables, step.config);
+			// VariableRender.render(this.variables, step.config);
 			StepRunner stepRunner;
 			Set<Step> predecessors = this.dag.predecessors(step);
 			switch (predecessors.size()) {

--- a/runner/src/main/java/org/ananas/runner/model/steps/commons/paginate/SourcePaginator.java
+++ b/runner/src/main/java/org/ananas/runner/model/steps/commons/paginate/SourcePaginator.java
@@ -1,7 +1,9 @@
 package org.ananas.runner.model.steps.commons.paginate;
 
 import com.google.common.base.Preconditions;
+import freemarker.template.TemplateException;
 import org.ananas.runner.misc.VariableRender;
+import org.ananas.runner.model.core.DagRequest;
 import org.ananas.runner.model.core.Dataframe;
 import org.ananas.runner.model.core.StepConfig;
 import org.ananas.runner.model.steps.api.APIPaginator;
@@ -19,6 +21,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.values.Row;
 import org.apache.commons.lang3.tuple.MutablePair;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class SourcePaginator implements Paginator {
@@ -36,9 +39,9 @@ public class SourcePaginator implements Paginator {
 	public static SourcePaginator of(String id,
 									 String type,
 									 Map<String, Object> config,
-									 Map<String, Object> variables) {
+									 Map<String, DagRequest.Variable> variables) {
 		Preconditions.checkNotNull(config, "config cannot be null");
-		VariableRender.render(variables, config);
+		config = VariableRender.renderConfig(variables, config);
 		StepType t = StepType.from(type);
 		return new SourcePaginator(id, t, config);
 	}

--- a/runner/src/test/java/org/ananas/runner/model/core/DagRequestTest.java
+++ b/runner/src/test/java/org/ananas/runner/model/core/DagRequestTest.java
@@ -2,6 +2,7 @@ package org.ananas.runner.model.core;
 
 import freemarker.template.TemplateException;
 import org.ananas.runner.api.JsonUtil;
+import org.apache.poi.ss.formula.functions.Offset;
 import org.junit.Test;
 
 import java.io.File;
@@ -10,6 +11,11 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -29,6 +35,15 @@ public class DagRequestTest {
 
 		assertEquals(6, newReq.dag.steps.size());
 
+		String dateStrValue = newReq.params.get("DATE_VAR").value;
+		DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+		OffsetDateTime offsetDateTime = OffsetDateTime.parse(dateStrValue);
+		Date date = Date.from(Instant.from(offsetDateTime));
+
+		SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy, HH:mm");
+		String dateString = sdf.format(date);
+
+
 		Iterator<Step> it = newReq.dag.steps.iterator();
 		while (it.hasNext()) {
 			Step step = it.next();
@@ -41,7 +56,7 @@ public class DagRequestTest {
 				assertEquals("123", step.config.get("xlabel"));
 
 				List<String> dimensions = (List<String>)step.config.get("dimension");
-				assertEquals("14.05.2019, 17:22", dimensions.get(0));
+				assertEquals(dateString, dimensions.get(0));
 			}
 
 		}

--- a/runner/src/test/java/org/ananas/runner/model/core/DagRequestTest.java
+++ b/runner/src/test/java/org/ananas/runner/model/core/DagRequestTest.java
@@ -1,0 +1,49 @@
+package org.ananas.runner.model.core;
+
+import freemarker.template.TemplateException;
+import org.ananas.runner.api.JsonUtil;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class DagRequestTest {
+
+	@Test
+	public void resolveVariables() throws IOException, TemplateException {
+		ClassLoader classLoader = getClass().getClassLoader();
+		URL resource = classLoader.getResource("dagrequests/example1.json");
+		String jsonRequest = new String(Files.readAllBytes(Paths.get(resource.getPath())), StandardCharsets.UTF_8);
+
+
+		DagRequest req = JsonUtil.fromJson(jsonRequest, DagRequest.class);
+		DagRequest newReq = req.resolveVariables();
+
+		assertEquals(6, newReq.dag.steps.size());
+
+		Iterator<Step> it = newReq.dag.steps.iterator();
+		while (it.hasNext()) {
+			Step step = it.next();
+
+			if (step.id.equals("5c969069d47a400e547d25d9")) {
+				assertEquals("some string value", step.config.get("path"));
+			}
+
+			if (step.id.equals("5c9697213cc63f7d6665abb0")) {
+				assertEquals("123", step.config.get("xlabel"));
+
+				List<String> dimensions = (List<String>)step.config.get("dimension");
+				assertEquals("14.05.2019, 17:22", dimensions.get(0));
+			}
+
+		}
+	}
+}

--- a/runner/src/test/resources/dagrequests/example1.json
+++ b/runner/src/test/resources/dagrequests/example1.json
@@ -1,0 +1,133 @@
+{
+  "dag": {
+    "connections": [
+      {
+        "source": "5c969069d47a400e547d25d9",
+        "target": "5c9696ad3cc63f7d6665abac"
+      },
+      {
+        "source": "5c9696ad3cc63f7d6665abac",
+        "target": "5c9697213cc63f7d6665abb0"
+      },
+      {
+        "source": "5c9696ad3cc63f7d6665abac",
+        "target": "5cd44293fe9f83e5131b8e02"
+      },
+      {
+        "source": "5c969069d47a400e547d25d9",
+        "target": "5cdaaf0ab37739e123fcf3a3"
+      },
+      {
+        "source": "5cdaaf0ab37739e123fcf3a3",
+        "target": "5cdaaf02b37739e123fcf3a1"
+      }
+    ],
+    "steps": [
+      {
+        "id": "5c969069d47a400e547d25d9",
+        "type": "connector",
+        "config": {
+          "format": "csv",
+          "header": true,
+          "path": "${STR_VAR}",
+          "subtype": "file"
+        }
+      },
+      {
+        "id": "5c9696ad3cc63f7d6665abac",
+        "type": "transformer",
+        "config": {
+          "sql": "SELECT \n\tcount(1) as cnt,\n  Nationality\nFROM PCOLLECTION\nGROUP BY Nationality\nORDER BY cnt DESC\nLIMIT 10",
+          "subtype": "sql"
+        }
+      },
+      {
+        "id": "5c9697213cc63f7d6665abb0",
+        "type": "viewer",
+        "config": {
+          "dimension": [
+            "${DATE_VAR?string['dd.MM.yyyy, HH:mm']}"
+          ],
+          "measures": [
+            "cnt"
+          ],
+          "sql": "SELECT * FROM PCOLLECTION\n",
+          "subtype": "bar chart",
+          "title": "Players By Nationality",
+          "xlabel": "${NUM_VAR?round}",
+          "ylabel": "Players"
+        }
+      },
+      {
+        "id": "5cd44293fe9f83e5131b8e02",
+        "type": "viewer",
+        "config": {
+          "dimension": [
+            "Nationality"
+          ],
+          "measures": [
+            "cnt"
+          ],
+          "sql": "SELECT * FROM PCOLLECTION",
+          "subtype": "line chart",
+          "title": "Player by nationality",
+          "xlabel": "Nationality",
+          "ylabel": "Player"
+        }
+      },
+      {
+        "id": "5cdaaf02b37739e123fcf3a1",
+        "type": "viewer",
+        "config": {
+          "color": "#7ed321",
+          "fields": [
+            "cnt"
+          ],
+          "size": "52px",
+          "sql": "SELECT * FROM PCOLLECTION",
+          "subtype": "big number",
+          "title": "Total Player"
+        }
+      },
+      {
+        "id": "5cdaaf0ab37739e123fcf3a3",
+        "type": "transformer",
+        "config": {
+          "sql": "SELECT count(1) as cnt\nFROM PCOLLECTION",
+          "subtype": "sql"
+        }
+      }
+    ]
+  },
+  "goals": [
+    "5cdaaf02b37739e123fcf3a1"
+  ],
+  "engine": {
+    "description": "default local Flink engine",
+    "name": "LOCAL",
+    "properties": {
+      "maxBundleSize": 1000000,
+      "objectReuse": true,
+      "parallelism": 10
+    },
+    "scope": "runtime",
+    "type": "Flink"
+  },
+  "params": {
+    "STR_VAR": {
+      "name": "STR_VAR",
+      "type": "string",
+      "value": "some string value"
+    },
+    "NUM_VAR": {
+      "name": "NUM_VAR",
+      "type": "number",
+      "value": "123.45"
+    },
+    "DATE_VAR": {
+      "name": "DATE_VAR",
+      "type": "date",
+      "value": "2019-05-14T15:22:59.414Z"
+    }
+  }
+}

--- a/ui/src/ui/service/ExecutionService.js
+++ b/ui/src/ui/service/ExecutionService.js
@@ -126,8 +126,8 @@ export default class ExecutionService {
       url: `${this.getRunnerURL()}/${step.id}/paginate?page=${page}&pagesize=${pageSize}`,
       data: {
         type: step.type,
-        config: this.variableService.injectExpressions(config, variables),
-        variables: {},
+        config, //this.variableService.injectExpressions(config, variables),
+        params: dict,
       }
     })
     .then(res=>{
@@ -145,17 +145,10 @@ export default class ExecutionService {
       // inject variables for each step
       let step = steps[id]
       let config = this.getStepConfig(step)
-      let variables = {}
-      let expressions = this.variableService.parseStepConfig(config)
-      for (let key in expressions) {
-        let expression = expressions[key]
-        // TODO: keep {} for client side injection, remove it when pass to server side injection
-        variables[key] = expression.eval(dict[expression.variable])
-      }
       newSteps.push({
         id,
         type: step.type,
-        config: this.variableService.injectExpressions(config, variables)
+        config,
       })
     }
     return axios({
@@ -172,7 +165,7 @@ export default class ExecutionService {
         goals: [
           runnableId
         ],
-        params: {},
+        params: dict,
       }
     })
     .then(res=>{
@@ -190,17 +183,10 @@ export default class ExecutionService {
       // inject variables for each step
       let step = steps[id]
       let config = this.getStepConfig(step)
-      let variables = {}
-      let expressions = this.variableService.parseStepConfig(config)
-      for (let key in expressions) {
-        let expression = expressions[key]
-        // TODO: keep {} for client side injection, remove it when pass to server side injection
-        variables[key] = expression.eval(dict[expression.variable])
-      }
       newSteps.push({
         id,
         type: step.type,
-        config: this.variableService.injectExpressions(config, variables)
+        config: config,
       })
     }
 
@@ -219,8 +205,7 @@ export default class ExecutionService {
         },
         goals: runnables,
         engine,
-        // env: { name: 'local', type: 'local' },
-        params: {},
+        params: dict,
       }
     })
     .then(res=>{

--- a/ui/src/ui/service/VariableService.js
+++ b/ui/src/ui/service/VariableService.js
@@ -153,7 +153,7 @@ export default class VariableService {
           let defaultDict = {}
           variables.forEach(v => {
             if (v.type === 'date') {
-              defaultDict[v.name] = moment().format()
+              defaultDict[v.name] = moment().toISOString()
             } else if (v.type === 'string') {
               defaultDict[v.name] = ''
             } else if (v.type === 'number') {
@@ -163,10 +163,18 @@ export default class VariableService {
           return defaultDict
         }
 
+        for (let k in dict) {
+          dict[k] = {
+            name: k,
+            type: variables.find(v => v.name === k) || 'string',
+            value: dict[k],
+          }
+        } 
+
         let newDict = { ... dict }  
         // override runtime variables, and remove unexpected variables
-        newDict['EXECUTE_DATE'] = moment().format() 
-        newDict['PROJECT_PATH'] = this.getProjectPath(projectID)
+        newDict['EXECUTE_DATE'] = {name: 'EXECUTE_DATE', type: 'date', value: moment().format()} 
+        newDict['PROJECT_PATH'] = {name: 'PROJECT_PATH', type: 'string', value: this.getProjectPath(projectID)}
         return newDict
       })
   }


### PR DESCRIPTION
- resolve variables on runner side with freemarker
- natually support string, number, and date type and several buit-in methods see freemarker doc: [freemarker](https://freemarker.apache.org/docs/ref_builtins.html)
- unify naming convention in explorer, test and run request body (variables now named as params)
- add unit test for variable resolving
- change UI side api wrapper to support the new request body format (the new params property format)