### PR TITLE
Fix Postgresql type autodetection

### DIFF
--- a/runner/src/main/java/org/ananas/runner/paginator/files/JdbcPaginator.java
+++ b/runner/src/main/java/org/ananas/runner/paginator/files/JdbcPaginator.java
@@ -92,6 +92,7 @@ public class JdbcPaginator extends AutoDetectedSchemaPaginator {
                   results.add(r);
                 }
               } catch (Exception e) {
+                LOG.warn("jdbc row mapping error", e.toString());
                 errors.addError(e);
               }
             }

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcConnector.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcConnector.java
@@ -18,8 +18,12 @@ import org.apache.beam.sdk.values.Row;
 import org.jooq.Query;
 import org.jooq.SelectQuery;
 import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JdbcConnector extends ConnectorStepRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcConnector.class);
 
   private JdbcStepConfig config;
 
@@ -66,6 +70,7 @@ public class JdbcConnector extends ConnectorStepRunner {
             .mapToObj(idx -> JdbcSchemaDetecter.autoCast(r, idx, schema))
             .collect(toRow(schema));
       } catch (Exception e) {
+        LOG.warn("error {}", e.toString());
         handler.addError(e);
         return null;
       }

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcSchemaDetecter.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcSchemaDetecter.java
@@ -14,6 +14,7 @@ import org.jooq.RecordType;
 import org.jooq.impl.DefaultRecordMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spark.utils.IOUtils;
 
 public class JdbcSchemaDetecter implements Serializable {
 
@@ -80,11 +81,14 @@ public class JdbcSchemaDetecter implements Serializable {
         Timestamp ts = resultSet.getTimestamp(idx + 1);
         return new DateTime(ts).toInstant();
       }
+      if (type.getTypeName().equals(Schema.FieldType.STRING.getTypeName()) || type.getTypeName().equals(Schema.FieldType.BYTES.getTypeName()) || type.getTypeName().equals(Schema.FieldType.BYTE.getTypeName())) {
+        return resultSet.getString(idx + 1);
+      }
       Class clazz = TypeInferer.getClass(type);
       return resultSet.getObject(idx + 1, clazz);
     } catch (Exception e) {
       LOG.warn(
-          "FETCH AUTOCAST WARNING : " + "idx= " + idx + " type: " + type + "  \n" + e.getMessage());
+          "FETCH AUTOCAST WARNING : idx= {} type: {}  \n {}", idx, type, e.getMessage());
     }
     return null;
   }

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcSchemaDetecter.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/JdbcSchemaDetecter.java
@@ -14,7 +14,6 @@ import org.jooq.RecordType;
 import org.jooq.impl.DefaultRecordMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import spark.utils.IOUtils;
 
 public class JdbcSchemaDetecter implements Serializable {
 
@@ -56,7 +55,11 @@ public class JdbcSchemaDetecter implements Serializable {
           metadata.getColumnTypeName(i) != null
               ? metadata.getColumnTypeName(i).toLowerCase()
               : "text";
-      LOG.debug("extracting schema column '{}' with type name '{}' to Beam Type '{}'", name, typeName, driver.getDefaultDataTypeLiteral(typeName));
+      LOG.debug(
+          "extracting schema column '{}' with type name '{}' to Beam Type '{}'",
+          name,
+          typeName,
+          driver.getDefaultDataTypeLiteral(typeName));
       builder.addNullableField(
           name,
           driver.getDefaultDataTypeLiteral(typeName) == null
@@ -96,8 +99,7 @@ public class JdbcSchemaDetecter implements Serializable {
           return resultSet.getObject(idx + 1, clazz);
       }
     } catch (Exception e) {
-      LOG.warn(
-          "FETCH AUTOCAST WARNING : idx= {} type: {}  \n {}", idx, type, e.getMessage());
+      LOG.warn("FETCH AUTOCAST WARNING : idx= {} type: {}  \n {}", idx, type, e.getMessage());
     }
     return null;
   }

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
@@ -15,14 +15,18 @@ public enum PostgresqlDataTypes implements JDBCDataType, DDL {
   BIT("bit", Schema.FieldType.STRING, false),
   BITVAR("bit varying", Schema.FieldType.STRING, false),
   BOOLEAN("boolean", Schema.FieldType.BOOLEAN.withNullable(true), true),
-  ARRAY_BOOLEAN("boolean[]", Schema.FieldType.array(Schema.FieldType.BOOLEAN).withNullable(true), true),
+  ARRAY_BOOLEAN(
+      "boolean[]", Schema.FieldType.array(Schema.FieldType.BOOLEAN).withNullable(true), true),
   BOOL("bool", Schema.FieldType.BOOLEAN, false),
   BYTE("byte", Schema.FieldType.BYTE, false),
   BYTES("bytes", Schema.FieldType.BYTES.withNullable(true), true),
   CHAR("char", Schema.FieldType.STRING, false),
   BPCHAR("bpchar", Schema.FieldType.STRING, false),
   CHARVAR("character varying", Schema.FieldType.STRING.withNullable(true), true),
-  CHARVAR_ARRAY("character varying[]", Schema.FieldType.array(Schema.FieldType.STRING).withNullable(true), true),
+  CHARVAR_ARRAY(
+      "character varying[]",
+      Schema.FieldType.array(Schema.FieldType.STRING).withNullable(true),
+      true),
   CHARACTER("character", Schema.FieldType.STRING, false),
   DATE_metadata(
       "date", Schema.FieldType.DATETIME.withMetadata("subtype", "DATE").withNullable(true), true),
@@ -41,9 +45,9 @@ public enum PostgresqlDataTypes implements JDBCDataType, DDL {
       Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ").withNullable(true),
       true),
   TIME_WITH_TIME_ZONE_metadata(
-          "time with time zone",
-          Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ").withNullable(true),
-          true),
+      "time with time zone",
+      Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ").withNullable(true),
+      true),
   TIMESTAMPZ_metadata(
       "timestamptz", Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ"), false),
   DECIMAL("decimal", Schema.FieldType.DECIMAL, false),

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
@@ -9,13 +9,14 @@ import org.apache.beam.sdk.schemas.Schema;
 
 public enum PostgresqlDataTypes implements JDBCDataType, DDL {
   BIGINT("bigint", Schema.FieldType.INT64.withNullable(true), true),
+  OID("oid", Schema.FieldType.BYTES.withNullable(true), true),
   BIGSERIAL("bigserial", Schema.FieldType.INT64.withNullable(true), true),
   BIT("bit", Schema.FieldType.STRING, false),
   BITVAR("bit varying", Schema.FieldType.STRING, false),
   BOOLEAN("boolean", Schema.FieldType.BOOLEAN.withNullable(true), true),
   BOOL("bool", Schema.FieldType.BOOLEAN, false),
   BYTE("byte", Schema.FieldType.BYTE, false),
-  BYTES("bytes", Schema.FieldType.BYTE.withNullable(true), true),
+  BYTES("bytes", Schema.FieldType.BYTES.withNullable(true), true),
   CHAR("char", Schema.FieldType.STRING, false),
   BPCHAR("bpchar", Schema.FieldType.STRING, false),
   CHARVAR("character varying", Schema.FieldType.STRING.withNullable(true), true),

--- a/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
+++ b/runner/src/main/java/org/ananas/runner/steprunner/jdbc/pgsql/PostgresqlDataTypes.java
@@ -9,17 +9,20 @@ import org.apache.beam.sdk.schemas.Schema;
 
 public enum PostgresqlDataTypes implements JDBCDataType, DDL {
   BIGINT("bigint", Schema.FieldType.INT64.withNullable(true), true),
-  OID("oid", Schema.FieldType.BYTES.withNullable(true), true),
+  OID("oid", Schema.FieldType.STRING.withNullable(true), true),
+  XID("xid", Schema.FieldType.STRING.withNullable(true), true),
   BIGSERIAL("bigserial", Schema.FieldType.INT64.withNullable(true), true),
   BIT("bit", Schema.FieldType.STRING, false),
   BITVAR("bit varying", Schema.FieldType.STRING, false),
   BOOLEAN("boolean", Schema.FieldType.BOOLEAN.withNullable(true), true),
+  ARRAY_BOOLEAN("boolean[]", Schema.FieldType.array(Schema.FieldType.BOOLEAN).withNullable(true), true),
   BOOL("bool", Schema.FieldType.BOOLEAN, false),
   BYTE("byte", Schema.FieldType.BYTE, false),
   BYTES("bytes", Schema.FieldType.BYTES.withNullable(true), true),
   CHAR("char", Schema.FieldType.STRING, false),
   BPCHAR("bpchar", Schema.FieldType.STRING, false),
   CHARVAR("character varying", Schema.FieldType.STRING.withNullable(true), true),
+  CHARVAR_ARRAY("character varying[]", Schema.FieldType.array(Schema.FieldType.STRING).withNullable(true), true),
   CHARACTER("character", Schema.FieldType.STRING, false),
   DATE_metadata(
       "date", Schema.FieldType.DATETIME.withMetadata("subtype", "DATE").withNullable(true), true),
@@ -37,6 +40,10 @@ public enum PostgresqlDataTypes implements JDBCDataType, DDL {
       "timestamp with time zone",
       Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ").withNullable(true),
       true),
+  TIME_WITH_TIME_ZONE_metadata(
+          "time with time zone",
+          Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ").withNullable(true),
+          true),
   TIMESTAMPZ_metadata(
       "timestamptz", Schema.FieldType.DATETIME.withMetadata("subtype", "TS_WITH_LOCAL_TZ"), false),
   DECIMAL("decimal", Schema.FieldType.DECIMAL, false),
@@ -112,7 +119,7 @@ public enum PostgresqlDataTypes implements JDBCDataType, DDL {
   }
 
   public Schema.FieldType getDefaultDataTypeLiteral(String datatypeLiteral) {
-    return dataTypes.get(datatypeLiteral);
+    return dataTypes.get(datatypeLiteral.toLowerCase());
   }
 
   public String rewrite(String url) {


### PR DESCRIPTION
Some binary types such as XID or OID were not correctly auto casted and was return as null value. Also the autodetector was case sensitive. 
